### PR TITLE
Change integer divisions to python 3 syntax: //

### DIFF
--- a/mpiFFT4py/line.py
+++ b/mpiFFT4py/line.py
@@ -1,3 +1,4 @@
+from __future__ import division
 __author__ = "Mikael Mortensen <mikaem@math.uio.no>"
 __date__ = "2016-02-16"
 __copyright__ = "Copyright (C) 2016 " + __author__
@@ -23,35 +24,35 @@ def transpose_y(Uc_hatT, U_recv, num_processes):
     return Uc_hatT
 
 def swap_Nq(fft_y, fu, fft_x, N):
-    f = fu[:, 0].copy()        
+    f = fu[:, 0].copy()
     fft_x[0] = f[0].real
-    fft_x[1:N/2] = 0.5*(f[1:N/2] + np.conj(f[:N/2:-1]))
-    fft_x[N/2] = f[N/2].real        
-    fu[:N/2+1, 0] = fft_x[:N/2+1]        
-    fu[N/2+1:, 0] = np.conj(fft_x[(N/2-1):0:-1])
-    
+    fft_x[1:N//2] = 0.5*(f[1:N//2] + np.conj(f[:N//2:-1]))
+    fft_x[N//2] = f[N//2].real
+    fu[:N//2+1, 0] = fft_x[:N//2+1]
+    fu[N//2+1:, 0] = np.conj(fft_x[(N//2-1):0:-1])
+
     fft_y[0] = f[0].imag
-    fft_y[1:N/2] = -0.5*1j*(f[1:N/2] - np.conj(f[:N/2:-1]))
-    fft_y[N/2] = f[N/2].imag
-    
-    fft_y[N/2+1:] = np.conj(fft_y[(N/2-1):0:-1])
+    fft_y[1:N//2] = -0.5*1j*(f[1:N//2] - np.conj(f[:N//2:-1]))
+    fft_y[N//2] = f[N//2].imag
+
+    fft_y[N//2+1:] = np.conj(fft_y[(N//2-1):0:-1])
     return fft_y
 
 class R2C(object):
     """Class for performing FFT in 2D using MPI
-    
+
     Slab decomposition
-    
+
     Args:
         N - NumPy array([Nx, Ny]) Number of nodes for the real mesh
         L - NumPy array([Lx, Ly]) The actual size of the real mesh
         comm - The MPI communicator object
         precision - "single" or "double"
         padsize - For performing transforms with padding
-        
+
     """
-    
-    def __init__(self, N, L, comm, precision, padsize=1.5, threads=1, 
+
+    def __init__(self, N, L, comm, precision, padsize=1.5, threads=1,
                  planner_effort=defaultdict(lambda : "FFTW_MEASURE")):
         self.N = N         # The global size of the problem
         self.L = L
@@ -65,9 +66,9 @@ class R2C(object):
         self.threads = threads
         self.planner_effort = planner_effort
         # Each cpu gets ownership of Np indices
-        self.Np = N / self.num_processes
-        self.Nf = N[1]/2+1
-        self.Npf = self.Np[1]/2+1 if self.rank+1 == self.num_processes else self.Np[1]/2
+        self.Np = N // self.num_processes
+        self.Nf = N[1]//2+1
+        self.Npf = self.Np[1]//2+1 if self.rank+1 == self.num_processes else self.Np[1]//2
         self.Nfp = int(padsize*self.N[1]/2+1)
         self.ks = (fftfreq(N[0])*N[0]).astype(int)
         self.dealias = zeros(0)
@@ -80,24 +81,24 @@ class R2C(object):
     def complex_shape(self):
         """The local shape of the complex data"""
         return (self.N[0], self.Npf)
-    
+
     def global_complex_shape(self):
         """The local shape of the complex data"""
         return (self.N[0], self.Nf)
-    
+
     def global_real_shape(self):
         """The local shape of the complex data"""
-        return (self.N[0], self.N[1])    
+        return (self.N[0], self.N[1])
 
     def real_local_slice(self, padsize=1):
-        return (slice(int(padsize*self.rank*self.Np[0]), 
+        return (slice(int(padsize*self.rank*self.Np[0]),
                       int(padsize*(self.rank+1)*self.Np[0]), 1),
                 slice(0, int(padsize*self.N[1])))
-    
+
     def complex_local_slice(self):
-        return (slice(0, self.N[0]), 
-                slice(self.rank*self.Np[1]/2, self.rank*self.Np[1]/2+self.Npf, 1))
-        
+        return (slice(0, self.N[0]),
+                slice(self.rank*self.Np[1]//2, self.rank*self.Np[1]//2+self.Npf, 1))
+
     def get_N(self):
         return self.N
 
@@ -107,32 +108,32 @@ class R2C(object):
         X[0] *= self.L[0]/self.N[0]
         X[1] *= self.L[1]/self.N[1]
         return X
-    
+
     def get_local_wavenumbermesh(self):
         kx = fftfreq(self.N[0], 1./self.N[0])
         ky = fftfreq(self.N[1], 1./self.N[1])[:self.Nf]
         ky[-1] *= -1
-        K = np.array(np.meshgrid(kx, ky[self.rank*self.Np[1]/2:(self.rank*self.Np[1]/2+self.Npf)], indexing='ij'), dtype=self.float)
+        K = np.array(np.meshgrid(kx, ky[self.rank*self.Np[1]//2:(self.rank*self.Np[1]//2+self.Npf)], indexing='ij'), dtype=self.float)
         return K
-    
+
     def get_scaled_local_wavenumbermesh(self):
         K = self.get_local_wavenumbermesh()
         Lp = 2*np.pi/self.L
         K[0] *= Lp[0]
         K[1] *= Lp[1]
         return K
-    
+
     def get_dealias_filter(self):
         """Filter for dealiasing nonlinear convection"""
         K = self.get_local_wavenumbermesh()
-        kmax = 2./3.*(self.N/2+1)
+        kmax = 2./3.*(self.N//2+1)
         dealias = np.array((abs(K[0]) < kmax[0])*(abs(K[1]) < kmax[1]), dtype=np.uint8)
         return dealias
-    
+
     def global_complex_shape_padded(self):
         """Global size of problem in complex wavenumber space"""
         return (int(self.padsize*self.N[0]), int(self.padsize*self.N[1]/2+1))
-    
+
     def real_shape_padded(self):
         """The local shape of the real data"""
         return (int(self.padsize*self.Np[0]), int(self.padsize*self.N[1]))
@@ -143,187 +144,187 @@ class R2C(object):
 
     def complex_shape_padded_01(self):
         """The local shape of the real data"""
-        return (int(self.padsize*self.Np[0]), self.Nf)    
-    
+        return (int(self.padsize*self.Np[0]), self.Nf)
+
     def complex_padded_x(self):
         """Padding in x-direction"""
         return (int(self.padsize*self.N[0]), self.Npf)
-    
+
     def work_shape(self, dealias):
         """Shape of work arrays used in convection with dealiasing. Different shape whether or not padding is involved"""
         if dealias == '3/2-rule':
             return self.real_shape_padded()
-        
+
         else:
             return self.real_shape()
 
     def copy_to_padded_x(self, fu, fp):
-        fp[:self.N[0]/2] = fu[:self.N[0]/2]
-        fp[-(self.N[0]/2):] = fu[self.N[0]/2:]
+        fp[:self.N[0]//2] = fu[:self.N[0]//2]
+        fp[-(self.N[0]//2):] = fu[self.N[0]//2:]
         return fp
 
     def copy_to_padded_y(self, fu, fp):
         fp[:, :self.Nf] = fu[:]
         return fp
-    
+
     def copy_from_padded_y(self, fp, fu):
         fu[:] = fp[:, :self.Nf]
         return fu
 
     def fft2(self, u, fu, dealias=None):
         assert dealias in ('3/2-rule', '2/3-rule', 'None', None)
-        
+
         if self.num_processes == 1:
             if not dealias == '3/2-rule':
                 fu = rfft2(u, fu, axes=(0,1), threads=self.threads, planner_effort=self.planner_effort['rfft2'])
-                
+
             else:
                 fu_padded = self.work_arrays[(self.global_complex_shape_padded(), self.complex, 0)]
-                fu_padded = rfft2(u/self.padsize**2, fu_padded, axes=(0,1), threads=self.threads, planner_effort=self.planner_effort['rfft2']) 
+                fu_padded = rfft2(u/self.padsize**2, fu_padded, axes=(0,1), threads=self.threads, planner_effort=self.planner_effort['rfft2'])
                 fu[:] = fu_padded[self.ks, :self.Nf]
-                
-            return fu    
-        
+
+            return fu
+
         if not dealias == '3/2-rule':
-        
+
             # Work arrays
             Uc_hatT = self.work_arrays[((self.Np[0], self.Nf), self.complex, 0)]
-            U_send  = self.work_arrays[((self.num_processes, self.Np[0], self.Np[1]/2), self.complex, 0)]
-            U_sendr = U_send.reshape((self.N[0], self.Np[1]/2))
-            Uc = self.work_arrays[((self.N[0], self.Np[1]/2), self.complex, 0)]
+            U_send  = self.work_arrays[((self.num_processes, self.Np[0], self.Np[1]//2), self.complex, 0)]
+            U_sendr = U_send.reshape((self.N[0], self.Np[1]//2))
+            Uc = self.work_arrays[((self.N[0], self.Np[1]//2), self.complex, 0)]
             fft_y = self.work_arrays[((self.N[0],), self.complex, 0)]
             fft_x = self.work_arrays[((self.N[0],), self.complex, 1)]
             plane_recv = self.work_arrays[((self.Np[0],), self.complex, 2)]
-            
+
             # Transform in y-direction
             Uc_hatT = rfft(u, Uc_hatT, axis=1, threads=self.threads, planner_effort=self.planner_effort['rfft'])
             Uc_hatT[:, 0] += 1j*Uc_hatT[:, -1]
-            
+
             U_send = transpose_x(U_send, Uc_hatT, self.num_processes)
-                    
+
             # Communicate all values
             self.comm.Alltoall(MPI.IN_PLACE, [U_send, self.mpitype])
-            
+
             Uc = fft(U_sendr, Uc, axis=0, threads=self.threads, planner_effort=self.planner_effort['fft'])
-            fu[:, :self.Np[1]/2] = Uc
-            
+            fu[:, :self.Np[1]//2] = Uc
+
             # Handle Nyquist frequency
-            if self.rank == 0:        
+            if self.rank == 0:
                 fft_y = swap_Nq(fft_y, fu, fft_x, self.N[0])
                 self.comm.Send([fft_y, self.mpitype], dest=self.num_processes-1, tag=77)
-                
+
             elif self.rank == self.num_processes-1:
                 self.comm.Recv([fft_y, self.mpitype], source=0, tag=77)
-                fu[:, -1] = fft_y 
-                
+                fu[:, -1] = fft_y
+
         else:
             # Work arrays
-            U_send  = self.work_arrays[((self.num_processes, int(self.padsize*self.Np[0]), self.Np[1]/2), self.complex, 0)]
-            U_sendr = U_send.reshape((int(self.padsize*self.N[0]), self.Np[1]/2))
+            U_send  = self.work_arrays[((self.num_processes, int(self.padsize*self.Np[0]), self.Np[1]//2), self.complex, 0)]
+            U_sendr = U_send.reshape((int(self.padsize*self.N[0]), self.Np[1]//2))
             fu_padded_xy = self.work_arrays[(self.complex_padded_xy(), self.complex, 0)]
             fu_padded_xy2 = self.work_arrays[(self.complex_shape_padded_01(), self.complex, 0)]
             fft_y = self.work_arrays[((self.N[0],), self.complex, 0)]
             fft_x = self.work_arrays[((self.N[0],), self.complex, 1)]
             plane_recv = self.work_arrays[((self.Np[0],), self.complex, 2)]
-                    
+
             # Transform in y-direction
             fu_padded_xy = rfft(u/self.padsize, fu_padded_xy, axis=1, threads=self.threads, planner_effort=self.planner_effort['rfft'])
             fu_padded_xy2 = self.copy_from_padded_y(fu_padded_xy, fu_padded_xy2)
             fu_padded_xy2[:, 0] += 1j*fu_padded_xy2[:, -1]
-            
+
             U_send = transpose_x(U_send, fu_padded_xy2, self.num_processes)
-                    
+
             # Communicate all values
             self.comm.Alltoall(MPI.IN_PLACE, [U_send, self.mpitype])
-            
+
             U_sendr = fft(U_sendr/self.padsize, U_sendr, axis=0, threads=self.threads, planner_effort=self.planner_effort['fft'])
-            
-            fu[:, :self.Np[1]/2] = U_sendr[self.ks]
-            
+
+            fu[:, :self.Np[1]//2] = U_sendr[self.ks]
+
             # Handle Nyquist frequency
-            if self.rank == 0:        
+            if self.rank == 0:
                 fft_y = swap_Nq(fft_y, fu, fft_x, self.N[0])
                 self.comm.Send([fft_y, self.mpitype], dest=self.num_processes-1, tag=77)
-                
+
             elif self.rank == self.num_processes-1:
                 self.comm.Recv([fft_y, self.mpitype], source=0, tag=77)
                 fu[:, -1] = fft_y
-                
+
         return fu
 
     def ifft2(self, fu, u, dealias=None):
         assert dealias in ('3/2-rule', '2/3-rule', 'None', None)
-        
+
         if dealias == '2/3-rule' and self.dealias.shape == (0,):
             self.dealias = self.get_dealias_filter()
 
         if dealias == '2/3-rule':
             fu *= self.dealias
-            
+
         if self.num_processes == 1:
-            if not dealias == '3/2-rule': 
+            if not dealias == '3/2-rule':
                 u = irfft2(fu, u, axes=(0,1), threads=self.threads, planner_effort=self.planner_effort['irfft2'])
-            
+
             else:
                 fu_padded = self.work_arrays[(self.global_complex_shape_padded(), self.complex, 0)]
                 fu_padded[self.ks, :self.Nf] = fu[:]
                 u = irfft2(fu_padded*self.padsize**2, u, axes=(0,1), threads=self.threads, planner_effort=self.planner_effort['irfft2'])
-                
+
             return u
 
         if not dealias == '3/2-rule':
-            # Get some work arrays            
+            # Get some work arrays
             Uc_hat  = self.work_arrays[((self.N[0], self.Npf), self.complex, 0)]
             Uc_hatT = self.work_arrays[((self.Np[0], self.Nf), self.complex, 0)]
-            U_send  = self.work_arrays[((self.num_processes, self.Np[0], self.Np[1]/2), self.complex, 0)]
-            U_sendr = U_send.reshape((self.N[0], self.Np[1]/2))
+            U_send  = self.work_arrays[((self.num_processes, self.Np[0], self.Np[1]//2), self.complex, 0)]
+            U_sendr = U_send.reshape((self.N[0], self.Np[1]//2))
             fft_y = self.work_arrays[((self.N[0],), self.complex, 0)]
             fft_x = self.work_arrays[((self.N[0],), self.complex, 1)]
             plane_recv = self.work_arrays[((self.Np[0],), self.complex, 2)]
 
-            Uc_hat = ifft(fu, Uc_hat, axis=0, threads=self.threads, planner_effort=self.planner_effort['ifft'])    
-            U_sendr[:] = Uc_hat[:, :self.Np[1]/2]
+            Uc_hat = ifft(fu, Uc_hat, axis=0, threads=self.threads, planner_effort=self.planner_effort['ifft'])
+            U_sendr[:] = Uc_hat[:, :self.Np[1]//2]
 
             self.comm.Alltoall(MPI.IN_PLACE, [U_send, self.mpitype])
 
             Uc_hatT = transpose_y(Uc_hatT, U_sendr, self.num_processes)
-            
+
             if self.rank == self.num_processes-1:
                 fft_y[:] = Uc_hat[:, -1]
 
             self.comm.Scatter(fft_y, plane_recv, root=self.num_processes-1)
             Uc_hatT[:, -1] = plane_recv
-            
+
             u = irfft(Uc_hatT, u, axis=1, threads=self.threads, planner_effort=self.planner_effort['irfft'])
-            
+
         else:
-            U_send  = self.work_arrays[((self.num_processes, int(self.padsize*self.Np[0]), self.Np[1]/2), self.complex, 0)]
-            U_sendr = U_send.reshape((int(self.padsize*self.N[0]), self.Np[1]/2))
-            Uc_hatT = self.work_arrays[((int(self.padsize*self.Np[0]), self.Nf), self.complex, 0)]            
-            fu_padded_x = self.work_arrays[(self.complex_padded_x(), self.complex, 0)] 
-            fu_padded_x2= self.work_arrays[(self.complex_padded_x(), self.complex, 1)] 
+            U_send  = self.work_arrays[((self.num_processes, int(self.padsize*self.Np[0]), self.Np[1]//2), self.complex, 0)]
+            U_sendr = U_send.reshape((int(self.padsize*self.N[0]), self.Np[1]//2))
+            Uc_hatT = self.work_arrays[((int(self.padsize*self.Np[0]), self.Nf), self.complex, 0)]
+            fu_padded_x = self.work_arrays[(self.complex_padded_x(), self.complex, 0)]
+            fu_padded_x2= self.work_arrays[(self.complex_padded_x(), self.complex, 1)]
             fu_padded_xy = self.work_arrays[(self.complex_padded_xy(), self.complex, 0)]
             fft_y = self.work_arrays[((int(self.padsize*self.N[0]),), self.complex, 0)]
             fft_x = self.work_arrays[((int(self.padsize*self.N[0]),), self.complex, 1)]
             plane_recv = self.work_arrays[((int(self.padsize*self.Np[0]),), self.complex, 2)]
-            
+
             fu_padded_x2 = self.copy_to_padded_x(fu, fu_padded_x2)
             fu_padded_x = ifft(fu_padded_x2, fu_padded_x, axis=0, threads=self.threads, planner_effort=self.planner_effort['ifft'])
-            
-            U_sendr[:] = fu_padded_x[:, :self.Np[1]/2]
+
+            U_sendr[:] = fu_padded_x[:, :self.Np[1]//2]
 
             self.comm.Alltoall(MPI.IN_PLACE, [U_send, self.mpitype])
 
             Uc_hatT = transpose_y(Uc_hatT, U_sendr, self.num_processes)
-            
+
             if self.rank == self.num_processes-1:
                 fft_y[:] = fu_padded_x[:, -1]
 
             self.comm.Scatter(fft_y, plane_recv, root=self.num_processes-1)
             Uc_hatT[:, -1] = plane_recv
-            
+
             fu_padded_xy = self.copy_to_padded_y(Uc_hatT, fu_padded_xy)
-            
+
             u = irfft(fu_padded_xy*self.padsize**2, u, axis=1, threads=self.threads, planner_effort=self.planner_effort['irfft'])
-            
+
         return u


### PR DESCRIPTION
Great tool! I am using it with python 3 where it works but gives deprecation warnings
about integer division. This can be fixed by simply replacing / with //.
I have tested that the test suite works with homebrew python 2.7.12 and python 3.5.2.
